### PR TITLE
Remove potential duplicates in the app list

### DIFF
--- a/core/model/src/main/java/com/merxury/blocker/core/model/data/AppItem.kt
+++ b/core/model/src/main/java/com/merxury/blocker/core/model/data/AppItem.kt
@@ -37,7 +37,16 @@ data class AppItem(
     val lastUpdateTime: Instant? = null,
     val appServiceStatus: AppServiceStatus? = null,
     val packageInfo: PackageInfo? = null,
-)
+) {
+    override fun equals(other: Any?): Boolean {
+        if (other !is AppItem) return false
+        return packageName == other.packageName
+    }
+
+    override fun hashCode(): Int {
+        return packageName.hashCode()
+    }
+}
 
 fun InstalledApp.toAppItem(
     packageInfo: PackageInfo? = null,

--- a/feature/applist/src/main/java/com/merxury/blocker/feature/applist/AppListViewModel.kt
+++ b/feature/applist/src/main/java/com/merxury/blocker/feature/applist/AppListViewModel.kt
@@ -153,7 +153,9 @@ class AppListViewModel @Inject constructor(
                     } else {
                         sortedList
                     }
-                }.toMutableStateList()
+                }
+                    .toSet()
+                    .toMutableStateList()
                 _appListFlow.value = _appList
                 _uiState.emit(Success)
             }


### PR DESCRIPTION
Trying to fix crash issue: 
```
Fatal Exception: java.lang.IllegalArgumentException: Key "com.lenovo.anyshare.gps" was already used. If you are using LazyColumn/Row please make sure you provide a unique key for each item.
       at androidx.compose.ui.layout.LayoutNodeSubcompositionsState.subcompose(LayoutNodeSubcompositionsState.java:436)
       at androidx.compose.ui.layout.LayoutNodeSubcompositionsState$Scope.subcompose(SubcomposeLayout.kt:862)
       at androidx.compose.foundation.lazy.layout.LazyLayoutMeasureScopeImpl.measure-0kLqBqw(LazyLayoutMeasureScope.kt:125)
       at androidx.compose.foundation.lazy.LazyListMeasuredItemProvider.getAndMeasure(LazyListMeasuredItemProvider.java:48)
       at androidx.compose.foundation.lazy.LazyListMeasureKt.measureLazyList-50ZNEM8(LazyListMeasure.kt:181)
       at androidx.compose.foundation.lazy.LazyListKt$rememberLazyListMeasurePolicy$1$1.invoke-0kLqBqw(LazyList.kt:322)
```