### PR TITLE
Fix `switchComponent` not working with Shizuku mode on Android 14.

### DIFF
--- a/core/component-controller/src/main/java/android/content/pm/IPackageManager.java
+++ b/core/component-controller/src/main/java/android/content/pm/IPackageManager.java
@@ -18,9 +18,11 @@ package android.content.pm;
 
 import android.content.ComponentName;
 import android.os.Binder;
+import android.os.Build;
 import android.os.IBinder;
 import android.os.IInterface;
 import android.os.RemoteException;
+import androidx.annotation.RequiresApi;
 
 public interface IPackageManager extends IInterface {
 
@@ -30,10 +32,18 @@ public interface IPackageManager extends IInterface {
     ParceledListSlice<PackageInfo> getInstalledPackages(int flags, int userId)
             throws RemoteException;
 
+    @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    void setComponentEnabledSetting(ComponentName componentName, int newState, int flags, int userId, String callingPackage)
+            throws RemoteException;
+
     void setComponentEnabledSetting(ComponentName componentName, int newState, int flags, int userId)
             throws RemoteException;
 
     int getComponentEnabledSetting(ComponentName componentName, int userId)
+            throws RemoteException;
+
+    @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    void setApplicationEnabledSetting(String packageName, int newState, int flags, int userId, String callingPackage)
             throws RemoteException;
 
     void setApplicationEnabledSetting(String packageName, int newState, int flags, int userId)

--- a/core/component-controller/src/main/kotlin/com/merxury/blocker/core/controllers/shizuku/ShizukuController.kt
+++ b/core/component-controller/src/main/kotlin/com/merxury/blocker/core/controllers/shizuku/ShizukuController.kt
@@ -21,6 +21,7 @@ import android.content.Context
 import android.content.pm.ComponentInfo
 import android.content.pm.IPackageManager
 import android.content.pm.PackageManager
+import android.os.Build
 import com.merxury.blocker.core.controllers.IController
 import com.merxury.blocker.core.utils.ApplicationUtil
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -46,7 +47,11 @@ class ShizukuController @Inject constructor(
             )
         }
         // 0 means kill the application
-        pm?.setComponentEnabledSetting(ComponentName(packageName, componentName), state, 0, 0)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            pm?.setComponentEnabledSetting(ComponentName(packageName, componentName), state, 0, 0, context.packageName)
+        } else {
+            pm?.setComponentEnabledSetting(ComponentName(packageName, componentName), state, 0, 0)
+        }
         return true
     }
 


### PR DESCRIPTION
Tested with Pixel 6a A14