### PR TITLE
Fix #573: Update provide status correctly

### DIFF
--- a/feature/appdetail/src/main/kotlin/com/merxury/blocker/feature/appdetail/AppDetailViewModel.kt
+++ b/feature/appdetail/src/main/kotlin/com/merxury/blocker/feature/appdetail/AppDetailViewModel.kt
@@ -700,7 +700,7 @@ class AppDetailViewModel @Inject constructor(
                 return@withContext
             }
             withContext(mainDispatcher) {
-                list[position] = if (currentController == IFW) {
+                list[position] = if (currentController == IFW && type != PROVIDER) {
                     list[position].copy(ifwBlocked = !enable)
                 } else {
                     list[position].copy(pmBlocked = !enable)


### PR DESCRIPTION
Fixes #573 🦕
Use pmStatus to indicate the current status of a provider. 
