### PR TITLE
Fix #724: show running service on the top

### DIFF
--- a/core/domain/src/test/kotlin/com/merxury/blocker/core/domain/components/SearchComponentsUseCaseTest.kt
+++ b/core/domain/src/test/kotlin/com/merxury/blocker/core/domain/components/SearchComponentsUseCaseTest.kt
@@ -143,7 +143,7 @@ class SearchComponentsUseCaseTest {
                     .sortedBy { it.simpleName.lowercase() },
                 service = listWithRunningService.filter { it.type == ComponentType.SERVICE }
                     .sortedBy { it.simpleName.lowercase() }
-                    .sortedByDescending { it.name == "5" },
+                    .sortedByDescending { it.isRunning },
                 receiver = components1.filter { it.type == ComponentType.RECEIVER }
                     .sortedBy { it.simpleName.lowercase() },
                 provider = components1.filter { it.type == ComponentType.PROVIDER }


### PR DESCRIPTION
Fix #724 
Cause: Sort the component list before fetching the service status