### PR TITLE
Compose buildFeature flag could be removed after AGP 8.5.1

### DIFF
--- a/build-logic/convention/src/main/kotlin/com/merxury/blocker/AndroidCompose.kt
+++ b/build-logic/convention/src/main/kotlin/com/merxury/blocker/AndroidCompose.kt
@@ -30,10 +30,6 @@ internal fun Project.configureAndroidCompose(
     commonExtension: CommonExtension<*, *, *, *, *, *>,
 ) {
     commonExtension.apply {
-        buildFeatures {
-            compose = true
-        }
-
         dependencies {
             val bom = libs.findLibrary("androidx-compose-bom").get()
             add("implementation", platform(bom))


### PR DESCRIPTION
It will be enabled after `org.jetbrains.kotlin.plugin.compose` is applied.

Depends on #922.