### PR TITLE
feat(debloater): Add @Preview annotations to UI components

### DIFF
--- a/feature/debloater/src/main/kotlin/com/merxury/blocker/feature/debloater/DebloatCollapsibleItem.kt
+++ b/feature/debloater/src/main/kotlin/com/merxury/blocker/feature/debloater/DebloatCollapsibleItem.kt
@@ -26,11 +26,13 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest.Builder
@@ -38,8 +40,11 @@ import com.merxury.blocker.core.designsystem.component.BlockerAppTopBarMenu
 import com.merxury.blocker.core.designsystem.component.BlockerBodyLargeText
 import com.merxury.blocker.core.designsystem.component.BlockerBodyMediumText
 import com.merxury.blocker.core.designsystem.component.DropDownMenuItem
+import com.merxury.blocker.core.designsystem.component.PreviewThemes
 import com.merxury.blocker.core.designsystem.icon.BlockerIcons
+import com.merxury.blocker.core.designsystem.theme.BlockerTheme
 import com.merxury.blocker.core.ui.R.string
+import com.merxury.blocker.feature.debloater.DebloaterPreviewParameterData.matchedTarget
 
 @Composable
 fun DebloatCollapsibleItem(
@@ -130,5 +135,31 @@ private fun DebloatAppInfo(
                 enabledCount,
             ),
         )
+    }
+}
+
+@Composable
+@PreviewThemes
+private fun DebloatCollapsibleItemCollapsedPreview() {
+    BlockerTheme {
+        Surface {
+            DebloatCollapsibleItem(
+                matchedTarget = matchedTarget,
+                expanded = false,
+            )
+        }
+    }
+}
+
+@Composable
+@PreviewThemes
+private fun DebloatCollapsibleItemExpandedPreview() {
+    BlockerTheme {
+        Surface {
+            DebloatCollapsibleItem(
+                matchedTarget = matchedTarget,
+                expanded = true,
+            )
+        }
     }
 }

--- a/feature/debloater/src/main/kotlin/com/merxury/blocker/feature/debloater/DebloatableAppList.kt
+++ b/feature/debloater/src/main/kotlin/com/merxury/blocker/feature/debloater/DebloatableAppList.kt
@@ -28,16 +28,21 @@ import androidx.compose.foundation.layout.windowInsetsBottomHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.toMutableStateMap
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastSumBy
+import com.merxury.blocker.core.designsystem.component.PreviewThemes
 import com.merxury.blocker.core.designsystem.component.scrollbar.DraggableScrollbar
 import com.merxury.blocker.core.designsystem.component.scrollbar.rememberDraggableScroller
 import com.merxury.blocker.core.designsystem.component.scrollbar.scrollbarState
+import com.merxury.blocker.core.designsystem.theme.BlockerTheme
 import com.merxury.blocker.core.ui.collapseList.rememberSavableSnapshotStateMap
 import timber.log.Timber
 
@@ -124,5 +129,32 @@ fun DebloatableAppList(
                 itemsAvailable = list.size,
             ),
         )
+    }
+}
+
+@Composable
+@PreviewThemes
+private fun DebloatableAppListPreview(
+    @PreviewParameter(DebloaterPreviewParameterProvider::class)
+    list: List<MatchedTarget>,
+) {
+    BlockerTheme {
+        Surface {
+            DebloatableAppList(
+                list = list,
+            )
+        }
+    }
+}
+
+@Composable
+@Preview
+private fun DebloatableAppListEmptyPreview() {
+    BlockerTheme {
+        Surface {
+            DebloatableAppList(
+                list = emptyList(),
+            )
+        }
     }
 }

--- a/feature/debloater/src/main/kotlin/com/merxury/blocker/feature/debloater/DebloatableAppSubItem.kt
+++ b/feature/debloater/src/main/kotlin/com/merxury/blocker/feature/debloater/DebloatableAppSubItem.kt
@@ -31,17 +31,24 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.merxury.blocker.core.designsystem.component.BlockerBodyLargeText
 import com.merxury.blocker.core.designsystem.component.BlockerBodyMediumText
 import com.merxury.blocker.core.designsystem.component.BlockerSwitch
+import com.merxury.blocker.core.designsystem.component.PreviewThemes
+import com.merxury.blocker.core.designsystem.theme.BlockerTheme
 import com.merxury.blocker.core.designsystem.theme.condensedRegular
 import com.merxury.blocker.feature.appdebloater.R
+import com.merxury.blocker.feature.debloater.DebloaterPreviewParameterData.debloaterComponentUiItem
+import com.merxury.blocker.feature.debloater.DebloaterPreviewParameterData.launcherOnlyComponent
+import com.merxury.blocker.feature.debloater.DebloaterPreviewParameterData.shareComponent
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
@@ -151,5 +158,71 @@ fun DebloatableAppSubItem(
                 onSwitchClick(item, !enabled)
             },
         )
+    }
+}
+
+@Composable
+@PreviewThemes
+private fun DebloatableAppSubItemPreview() {
+    BlockerTheme {
+        Surface {
+            DebloatableAppSubItem(
+                item = debloaterComponentUiItem,
+                enabled = true,
+            )
+        }
+    }
+}
+
+@Composable
+@PreviewThemes
+private fun DebloatableAppSubItemDisabledPreview() {
+    BlockerTheme {
+        Surface {
+            DebloatableAppSubItem(
+                item = debloaterComponentUiItem,
+                enabled = false,
+            )
+        }
+    }
+}
+
+@Composable
+@PreviewThemes
+private fun DebloatableAppSubItemSelectedPreview() {
+    BlockerTheme {
+        Surface {
+            DebloatableAppSubItem(
+                item = debloaterComponentUiItem,
+                enabled = true,
+                isSelected = true,
+            )
+        }
+    }
+}
+
+@Composable
+@PreviewThemes
+private fun DebloatableAppSubItemLauncherOnlyPreview() {
+    BlockerTheme {
+        Surface {
+            DebloatableAppSubItem(
+                item = launcherOnlyComponent,
+                enabled = true,
+            )
+        }
+    }
+}
+
+@Composable
+@Preview
+private fun DebloatableAppSubItemShareOnlyPreview() {
+    BlockerTheme {
+        Surface {
+            DebloatableAppSubItem(
+                item = shareComponent,
+                enabled = true,
+            )
+        }
     }
 }

--- a/feature/debloater/src/main/kotlin/com/merxury/blocker/feature/debloater/DebloaterContent.kt
+++ b/feature/debloater/src/main/kotlin/com/merxury/blocker/feature/debloater/DebloaterContent.kt
@@ -16,9 +16,14 @@
 
 package com.merxury.blocker.feature.debloater
 
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import com.merxury.blocker.core.designsystem.component.PreviewThemes
+import com.merxury.blocker.core.designsystem.theme.BlockerTheme
 import com.merxury.blocker.core.result.Result
 import com.merxury.blocker.core.ui.component.NoComponentScreen
 import com.merxury.blocker.core.ui.data.UiMessage
@@ -52,5 +57,56 @@ fun DebloaterContent(
         is Result.Error -> ErrorScreen(error = UiMessage(title = data.exception.message.orEmpty()))
 
         is Result.Loading -> LoadingScreen()
+    }
+}
+
+@Composable
+@PreviewThemes
+private fun DebloaterContentSuccessPreview(
+    @PreviewParameter(DebloaterPreviewParameterProvider::class)
+    list: List<MatchedTarget>,
+) {
+    BlockerTheme {
+        Surface {
+            DebloaterContent(
+                data = Result.Success(list),
+            )
+        }
+    }
+}
+
+@Composable
+@Preview
+private fun DebloaterContentEmptyPreview() {
+    BlockerTheme {
+        Surface {
+            DebloaterContent(
+                data = Result.Success(emptyList()),
+            )
+        }
+    }
+}
+
+@Composable
+@PreviewThemes
+private fun DebloaterContentLoadingPreview() {
+    BlockerTheme {
+        Surface {
+            DebloaterContent(
+                data = Result.Loading,
+            )
+        }
+    }
+}
+
+@Composable
+@Preview
+private fun DebloaterContentErrorPreview() {
+    BlockerTheme {
+        Surface {
+            DebloaterContent(
+                data = Result.Error(Exception("Failed to load debloatable components")),
+            )
+        }
     }
 }

--- a/feature/debloater/src/main/kotlin/com/merxury/blocker/feature/debloater/DebloaterPreviewParameterProvider.kt
+++ b/feature/debloater/src/main/kotlin/com/merxury/blocker/feature/debloater/DebloaterPreviewParameterProvider.kt
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2025 Blocker
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.merxury.blocker.feature.debloater
+
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import com.merxury.blocker.core.database.debloater.DebloatableComponentEntity
+import com.merxury.blocker.core.domain.model.MatchedHeaderData
+import com.merxury.blocker.core.model.ComponentType
+import com.merxury.blocker.core.model.data.IntentFilterDataInfo
+import com.merxury.blocker.core.model.data.IntentFilterInfo
+
+class DebloaterPreviewParameterProvider : PreviewParameterProvider<List<MatchedTarget>> {
+    override val values: Sequence<List<MatchedTarget>> = sequenceOf(DebloaterPreviewParameterData.debloaterList)
+}
+
+object DebloaterPreviewParameterData {
+
+    private val launcherIntentFilter = IntentFilterInfo(
+        actions = listOf("android.intent.action.MAIN"),
+        categories = listOf("android.intent.category.LAUNCHER"),
+        data = emptyList(),
+    )
+
+    private val shareIntentFilter = IntentFilterInfo(
+        actions = listOf("android.intent.action.SEND"),
+        categories = listOf("android.intent.category.DEFAULT"),
+        data = listOf(
+            IntentFilterDataInfo(mimeType = "text/plain"),
+        ),
+    )
+
+    private val deeplinkIntentFilter = IntentFilterInfo(
+        actions = listOf("android.intent.action.VIEW"),
+        categories = listOf("android.intent.category.DEFAULT", "android.intent.category.BROWSABLE"),
+        data = listOf(
+            IntentFilterDataInfo(scheme = "https", host = "example.com"),
+        ),
+    )
+
+    val debloaterComponentUiItem = DebloatableComponentUiItem(
+        entity = DebloatableComponentEntity(
+            packageName = "com.example.app",
+            componentName = "com.example.app.MainActivity",
+            simpleName = "MainActivity",
+            displayName = "Main Activity",
+            ifwBlocked = false,
+            pmBlocked = false,
+            type = ComponentType.ACTIVITY,
+            exported = true,
+            label = "Main",
+            intentFilters = listOf(launcherIntentFilter, shareIntentFilter, deeplinkIntentFilter),
+        ),
+        isShareableComponent = true,
+        isExplicitLaunch = true,
+        isLauncherEntry = true,
+        isDeeplinkEntry = true,
+    )
+
+    val launcherOnlyComponent = DebloatableComponentUiItem(
+        entity = DebloatableComponentEntity(
+            packageName = "com.example.app",
+            componentName = "com.example.app.LauncherActivity",
+            simpleName = "LauncherActivity",
+            displayName = "Launcher",
+            ifwBlocked = false,
+            pmBlocked = false,
+            type = ComponentType.ACTIVITY,
+            exported = true,
+            label = "Launcher",
+            intentFilters = listOf(launcherIntentFilter),
+        ),
+        isShareableComponent = false,
+        isExplicitLaunch = true,
+        isLauncherEntry = true,
+        isDeeplinkEntry = false,
+    )
+
+    val blockedComponent = DebloatableComponentUiItem(
+        entity = DebloatableComponentEntity(
+            packageName = "com.example.app",
+            componentName = "com.example.app.BlockedActivity",
+            simpleName = "BlockedActivity",
+            displayName = "",
+            ifwBlocked = true,
+            pmBlocked = false,
+            type = ComponentType.ACTIVITY,
+            exported = false,
+            label = null,
+            intentFilters = emptyList(),
+        ),
+        isShareableComponent = false,
+        isExplicitLaunch = false,
+        isLauncherEntry = false,
+        isDeeplinkEntry = false,
+    )
+
+    val shareComponent = DebloatableComponentUiItem(
+        entity = DebloatableComponentEntity(
+            packageName = "com.example.app",
+            componentName = "com.example.app.ShareActivity",
+            simpleName = "ShareActivity",
+            displayName = "Share Handler",
+            ifwBlocked = false,
+            pmBlocked = false,
+            type = ComponentType.ACTIVITY,
+            exported = true,
+            label = "Share",
+            intentFilters = listOf(shareIntentFilter),
+        ),
+        isShareableComponent = true,
+        isExplicitLaunch = true,
+        isLauncherEntry = false,
+        isDeeplinkEntry = false,
+    )
+
+    val deeplinkComponent = DebloatableComponentUiItem(
+        entity = DebloatableComponentEntity(
+            packageName = "com.example.app",
+            componentName = "com.example.app.DeeplinkActivity",
+            simpleName = "DeeplinkActivity",
+            displayName = "Deeplink Handler",
+            ifwBlocked = false,
+            pmBlocked = false,
+            type = ComponentType.ACTIVITY,
+            exported = true,
+            label = "Deeplink",
+            intentFilters = listOf(deeplinkIntentFilter),
+        ),
+        isShareableComponent = false,
+        isExplicitLaunch = true,
+        isLauncherEntry = false,
+        isDeeplinkEntry = true,
+    )
+
+    val matchedTarget = MatchedTarget(
+        header = MatchedHeaderData(
+            title = "Example App",
+            uniqueId = "com.example.app",
+            icon = null,
+        ),
+        targets = listOf(
+            debloaterComponentUiItem,
+            launcherOnlyComponent,
+            shareComponent,
+            deeplinkComponent,
+            blockedComponent,
+        ),
+    )
+
+    val secondMatchedTarget = MatchedTarget(
+        header = MatchedHeaderData(
+            title = "Another App",
+            uniqueId = "com.example.another",
+            icon = null,
+        ),
+        targets = listOf(
+            DebloatableComponentUiItem(
+                entity = DebloatableComponentEntity(
+                    packageName = "com.example.another",
+                    componentName = "com.example.another.MainActivity",
+                    simpleName = "MainActivity",
+                    displayName = "Main Activity",
+                    ifwBlocked = false,
+                    pmBlocked = false,
+                    type = ComponentType.ACTIVITY,
+                    exported = true,
+                    label = "Main",
+                    intentFilters = listOf(launcherIntentFilter),
+                ),
+                isShareableComponent = false,
+                isExplicitLaunch = true,
+                isLauncherEntry = true,
+                isDeeplinkEntry = false,
+            ),
+            DebloatableComponentUiItem(
+                entity = DebloatableComponentEntity(
+                    packageName = "com.example.another",
+                    componentName = "com.example.another.BackgroundService",
+                    simpleName = "BackgroundService",
+                    displayName = "",
+                    ifwBlocked = false,
+                    pmBlocked = true,
+                    type = ComponentType.SERVICE,
+                    exported = false,
+                    label = null,
+                    intentFilters = emptyList(),
+                ),
+                isShareableComponent = false,
+                isExplicitLaunch = false,
+                isLauncherEntry = false,
+                isDeeplinkEntry = false,
+            ),
+        ),
+    )
+
+    val debloaterList: List<MatchedTarget> = listOf(
+        matchedTarget,
+        secondMatchedTarget,
+    )
+}

--- a/feature/debloater/src/main/kotlin/com/merxury/blocker/feature/debloater/DebloaterScreen.kt
+++ b/feature/debloater/src/main/kotlin/com/merxury/blocker/feature/debloater/DebloaterScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.layout.windowInsetsTopHeight
 import androidx.compose.material3.FilledTonalIconButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -36,13 +37,17 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.merxury.blocker.core.designsystem.component.BlockerErrorAlertDialog
 import com.merxury.blocker.core.designsystem.component.BlockerSearchTextField
+import com.merxury.blocker.core.designsystem.component.PreviewThemes
 import com.merxury.blocker.core.designsystem.component.SnackbarHostState
 import com.merxury.blocker.core.designsystem.icon.BlockerIcons
+import com.merxury.blocker.core.designsystem.theme.BlockerTheme
 import com.merxury.blocker.core.result.Result
 import com.merxury.blocker.core.ui.data.UiMessage
 import com.merxury.blocker.feature.appdebloater.R
@@ -147,5 +152,68 @@ internal fun DebloaterScreenContent(
             text = errorState.content.orEmpty(),
             onDismissRequest = onDismissError,
         )
+    }
+}
+
+@Composable
+@PreviewThemes
+private fun DebloaterScreenContentPreview(
+    @PreviewParameter(DebloaterPreviewParameterProvider::class)
+    list: List<MatchedTarget>,
+) {
+    BlockerTheme {
+        Surface {
+            DebloaterScreenContent(
+                snackbarHostState = SnackbarHostState(),
+                debloatableUiState = Result.Success(list),
+                searchQuery = "",
+            )
+        }
+    }
+}
+
+@Composable
+@Preview
+private fun DebloaterScreenContentWithSearchPreview() {
+    BlockerTheme {
+        Surface {
+            DebloaterScreenContent(
+                snackbarHostState = SnackbarHostState(),
+                debloatableUiState = Result.Success(DebloaterPreviewParameterData.debloaterList),
+                searchQuery = "Main",
+            )
+        }
+    }
+}
+
+@Composable
+@Preview
+private fun DebloaterScreenContentWithErrorDialogPreview() {
+    BlockerTheme {
+        Surface {
+            DebloaterScreenContent(
+                snackbarHostState = SnackbarHostState(),
+                debloatableUiState = Result.Success(DebloaterPreviewParameterData.debloaterList),
+                searchQuery = "",
+                errorState = UiMessage(
+                    title = "Error",
+                    content = "Failed to disable component",
+                ),
+            )
+        }
+    }
+}
+
+@Composable
+@Preview
+private fun DebloaterScreenContentLoadingPreview() {
+    BlockerTheme {
+        Surface {
+            DebloaterScreenContent(
+                snackbarHostState = SnackbarHostState(),
+                debloatableUiState = Result.Loading,
+                searchQuery = "",
+            )
+        }
     }
 }


### PR DESCRIPTION
- Add DebloaterPreviewParameterProvider with sample data
- Add preview functions to DebloatableAppSubItem showing different states
- Add preview functions to DebloatableAppList including empty state
- Add preview functions to DebloatCollapsibleItem for collapsed/expanded states
- Add preview functions to DebloaterContent for success/loading/error states
- Add preview functions to DebloaterScreen for various UI states

This allows developers to quickly preview UI components in Android Studio.

Change-Id: Icf1586adb83e274998e4d7b52fd98765eb3038ea
