### PR TITLE
Replace Enum.values() with Enum.entries

### DIFF
--- a/build-logic/convention/src/main/kotlin/com/merxury/blocker/BlockerFlavor.kt
+++ b/build-logic/convention/src/main/kotlin/com/merxury/blocker/BlockerFlavor.kt
@@ -39,11 +39,11 @@ fun configureFlavors(
     flavorConfigurationBlock: ProductFlavor.(flavor: BlockerFlavor) -> Unit = {},
 ) {
     commonExtension.apply {
-        FlavorDimension.values().forEach { flavorDimension ->
+        FlavorDimension.entries.forEach { flavorDimension ->
             flavorDimensions += flavorDimension.name
         }
         productFlavors {
-            BlockerFlavor.values().forEach { blockerFlavor ->
+            BlockerFlavor.entries.forEach { blockerFlavor ->
                 register(blockerFlavor.name) {
                     dimension = blockerFlavor.dimension.name
                     flavorConfigurationBlock(this, blockerFlavor)


### PR DESCRIPTION
## Summary
- Replace `FlavorDimension.values()` with `FlavorDimension.entries` in `BlockerFlavor.kt`
- Replace `BlockerFlavor.values()` with `BlockerFlavor.entries` in `BlockerFlavor.kt`
- `Enum.entries` (Kotlin 1.9+) is more efficient (returns immutable list vs new array)

## Test plan
- [ ] `./gradlew -p build-logic check` passes
- [ ] `./gradlew assembleFossDebug` builds successfully