### PR TITLE
Add -repackageclasses to R8 configuration

### DIFF
--- a/app-compose/proguard-rules.pro
+++ b/app-compose/proguard-rules.pro
@@ -3,3 +3,5 @@
 -keep class com.merxury.** { *; }
 # Keep file names and line numbers for Crashlytics.
 -keepattributes SourceFile,LineNumberTable
+# Repackage obfuscated classes into a flat package to reduce descriptor sizes
+-repackageclasses


### PR DESCRIPTION
## Summary
- Add `-repackageclasses` to ProGuard/R8 rules for release builds
- Repackages obfuscated classes into a flat package, reducing descriptor sizes and APK size

## Test plan
- [x] `./gradlew assembleMarketRelease` builds successfully
- [ ] Verify release APK is functional