### PR TITLE
Fix sort option selection resetting after device rotation (#1418)

### DIFF
--- a/core/designsystem/src/main/kotlin/com/merxury/blocker/core/designsystem/segmentedbuttons/SegmentedButtons.kt
+++ b/core/designsystem/src/main/kotlin/com/merxury/blocker/core/designsystem/segmentedbuttons/SegmentedButtons.kt
@@ -43,8 +43,6 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -72,17 +70,15 @@ fun <T> SegmentedButtons(
     modifier: Modifier = Modifier,
     onItemSelection: (item: T) -> Unit = {},
 ) {
-    val selectedItem = remember { mutableStateOf(selectedValue) }
     SegmentedButtons(modifier = modifier.fillMaxWidth()) {
         items.forEachIndexed { _, item ->
             SegmentedButtonItem(
-                selected = selectedItem.value == item.first,
+                selected = selectedValue == item.first,
                 onClick = {
-                    selectedItem.value = item.first
                     onItemSelection(item.first)
                 },
                 label = {
-                    if (selectedItem.value == item.first) {
+                    if (selectedValue == item.first) {
                         Icon(
                             imageVector = BlockerIcons.CheckSmall,
                             contentDescription = null,

--- a/feature/appdetail/impl/src/main/kotlin/com/merxury/blocker/feature/appdetail/impl/bottomsheet/ComponentSortViewModel.kt
+++ b/feature/appdetail/impl/src/main/kotlin/com/merxury/blocker/feature/appdetail/impl/bottomsheet/ComponentSortViewModel.kt
@@ -16,7 +16,6 @@
 
 package com.merxury.blocker.feature.appdetail.impl.bottomsheet
 
-import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.merxury.blocker.core.data.respository.userdata.UserDataRepository
@@ -29,7 +28,7 @@ import com.merxury.blocker.feature.appdetail.impl.bottomsheet.ComponentSortInfoU
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -43,18 +42,15 @@ class ComponentSortViewModel @Inject constructor(
     val componentSortInfoUiState = _componentSortInfoUiState.asStateFlow()
 
     init {
-        loadComponentSortInfo()
-    }
-
-    @VisibleForTesting
-    fun loadComponentSortInfo() = viewModelScope.launch {
-        val userData = userDataRepository.userData.first()
-        val sorting = userData.componentSorting
-        val order = userData.componentSortingOrder
-        val priority = userData.componentShowPriority
-        _componentSortInfoUiState.emit(
-            Success(ComponentSortInfo(sorting, order, priority)),
-        )
+        viewModelScope.launch {
+            userDataRepository.userData
+                .map { userData ->
+                    Success(
+                        ComponentSortInfo(userData.componentSorting, userData.componentSortingOrder, userData.componentShowPriority),
+                    )
+                }
+                .collect { _componentSortInfoUiState.value = it }
+        }
     }
 
     fun updateComponentSorting(sorting: ComponentSorting) = viewModelScope.launch {

--- a/feature/appdetail/impl/src/test/kotlin/com/merxury/blocker/feature/appdetail/impl/ComponentSortViewModelTest.kt
+++ b/feature/appdetail/impl/src/test/kotlin/com/merxury/blocker/feature/appdetail/impl/ComponentSortViewModelTest.kt
@@ -76,7 +76,6 @@ class ComponentSortViewModelTest {
 
         userDataRepository.sendUserData(defaultUserData)
         viewModel.updateComponentSorting(ComponentSorting.PACKAGE_NAME)
-        viewModel.loadComponentSortInfo()
         val updatedUserData = defaultUserData.copy(componentSorting = ComponentSorting.PACKAGE_NAME)
         assertEquals(
             Success(updatedUserData.toComponentSortInfo()),
@@ -94,7 +93,6 @@ class ComponentSortViewModelTest {
 
         userDataRepository.sendUserData(defaultUserData)
         viewModel.updateComponentSortingOrder(SortingOrder.DESCENDING)
-        viewModel.loadComponentSortInfo()
         val updatedUserData =
             defaultUserData.copy(componentSortingOrder = SortingOrder.DESCENDING)
         assertEquals(
@@ -113,7 +111,6 @@ class ComponentSortViewModelTest {
 
         userDataRepository.sendUserData(defaultUserData)
         viewModel.updateComponentShowPriority(ComponentShowPriority.ENABLED_COMPONENTS_FIRST)
-        viewModel.loadComponentSortInfo()
         val updatedUserData =
             defaultUserData.copy(componentShowPriority = ComponentShowPriority.ENABLED_COMPONENTS_FIRST)
         assertEquals(

--- a/feature/applist/impl/src/test/kotlin/com/merxury/blocker/feature/applist/impl/AppSortViewModelTest.kt
+++ b/feature/applist/impl/src/test/kotlin/com/merxury/blocker/feature/applist/impl/AppSortViewModelTest.kt
@@ -73,7 +73,6 @@ class AppSortViewModelTest {
 
         userDataRepository.sendUserData(defaultUserData)
         viewModel.updateAppSorting(AppSorting.LAST_UPDATE_TIME)
-        viewModel.loadAppSortInfo()
         val updatedUserData = defaultUserData.copy(appSorting = AppSorting.LAST_UPDATE_TIME)
         assertEquals(
             Success(updatedUserData.toAppSortInfo()),
@@ -91,7 +90,6 @@ class AppSortViewModelTest {
 
         userDataRepository.sendUserData(defaultUserData)
         viewModel.updateAppSortingOrder(SortingOrder.DESCENDING)
-        viewModel.loadAppSortInfo()
         val updatedUserData = defaultUserData.copy(appSortingOrder = SortingOrder.DESCENDING)
         assertEquals(
             Success(updatedUserData.toAppSortInfo()),
@@ -109,7 +107,6 @@ class AppSortViewModelTest {
 
         userDataRepository.sendUserData(defaultUserData)
         viewModel.updateShowRunningAppsOnTop(true)
-        viewModel.loadAppSortInfo()
         val updatedUserData = defaultUserData.copy(showRunningAppsOnTop = true)
         assertEquals(
             Success(updatedUserData.toAppSortInfo()),


### PR DESCRIPTION
Replace one-shot .first() reads with continuous Flow observation in AppSortViewModel and ComponentSortViewModel so UI state stays in sync with DataStore. Remove internal remember state from SegmentedButtons to make it a properly controlled component.

Closes #1418 
