### PR TITLE
Fix force stop crash when app list changes concurrently

### DIFF
--- a/feature/applist/impl/src/main/kotlin/com/merxury/blocker/feature/applist/impl/AppListViewModel.kt
+++ b/feature/applist/impl/src/main/kotlin/com/merxury/blocker/feature/applist/impl/AppListViewModel.kt
@@ -353,11 +353,15 @@ class AppListViewModel @AssistedInject constructor(
         val appController = getAppController().first()
         appController.forceStop(packageName)
         appController.refreshRunningAppList()
-        val item = appList.find { it.packageName == packageName }
-        if (item != null) {
-            val index = appStateList.indexOf(item)
-            val newItem = item.copy(isRunning = appController.isAppRunning(packageName))
-            appStateList[index] = newItem
+        val isRunning = appController.isAppRunning(packageName)
+        withContext(mainDispatcher) {
+            val item = appList.find { it.packageName == packageName }
+            if (item != null) {
+                val index = appStateList.indexOf(item)
+                if (index != -1) {
+                    appStateList[index] = item.copy(isRunning = isRunning)
+                }
+            }
         }
         analyticsHelper.logForceStopClicked()
     }


### PR DESCRIPTION
## Summary
- Fix `IndexOutOfBoundsException` in `AppListViewModel.forceStop()` caused by a race condition between `appList` and `appStateList`
- Guard against `indexOf` returning `-1` before accessing the `SnapshotStateList`
- Move `SnapshotStateList` mutation to main dispatcher for thread safety, consistent with other list update sites in the ViewModel

## Root Cause
When force-stopping an app (especially long-running system apps like Google Play Services), other coroutines (`loadData`, `listenSortingChanges`, etc.) could reassign `appStateList` during execution. This caused `indexOf` to return `-1`, and `appStateList[-1]` threw an `IndexOutOfBoundsException` on the internal `PersistentVector`.

## Test plan
- [x] `./gradlew :feature:applist:impl:testFossDebugUnitTest` passes

Fixes #613