### PR TITLE
fix: replace snackbar-based batch progress with state-driven composable

### DIFF
--- a/core/ui/src/main/kotlin/com/merxury/blocker/core/ui/ProcessingProgressSnackbar.kt
+++ b/core/ui/src/main/kotlin/com/merxury/blocker/core/ui/ProcessingProgressSnackbar.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2026 Blocker
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.merxury.blocker.core.ui
+
+import android.content.Context
+import android.os.Build
+import android.view.accessibility.AccessibilityManager
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
+import com.merxury.blocker.core.ui.R.string as uistring
+
+private const val COMPLETED_DISPLAY_MILLIS = 2000
+
+data class ProcessingProgress(
+    val current: Int,
+    val total: Int,
+    val isEnabling: Boolean,
+)
+
+@Composable
+fun ProcessingProgressSnackbar(
+    progress: ProcessingProgress?,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val isCompleted = progress != null && progress.current >= progress.total
+    val context = LocalContext.current
+    LaunchedEffect(isCompleted) {
+        if (isCompleted) {
+            val timeout = getRecommendedTimeout(context, COMPLETED_DISPLAY_MILLIS)
+            delay(timeout)
+            onDismiss()
+        }
+    }
+    var lastProgress by remember { mutableStateOf(progress) }
+    if (progress != null) {
+        lastProgress = progress
+    }
+    AnimatedVisibility(
+        visible = progress != null,
+        modifier = modifier,
+        enter = fadeIn() + slideInVertically { it },
+        exit = fadeOut() + slideOutVertically { it },
+    ) {
+        lastProgress?.let { displayProgress ->
+            val message = if (displayProgress.current >= displayProgress.total) {
+                stringResource(uistring.core_ui_operation_completed)
+            } else if (displayProgress.isEnabling) {
+                stringResource(
+                    uistring.core_ui_enabling_component_hint,
+                    displayProgress.current,
+                    displayProgress.total,
+                )
+            } else {
+                stringResource(
+                    uistring.core_ui_disabling_component_hint,
+                    displayProgress.current,
+                    displayProgress.total,
+                )
+            }
+            Surface(
+                modifier = Modifier.fillMaxWidth(),
+                shape = MaterialTheme.shapes.small,
+                color = MaterialTheme.colorScheme.inverseSurface,
+                shadowElevation = 6.dp,
+            ) {
+                Text(
+                    text = message,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 14.dp),
+                    color = MaterialTheme.colorScheme.inverseOnSurface,
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            }
+        }
+    }
+}
+
+private fun getRecommendedTimeout(context: Context, originalTimeoutMs: Int): Long {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        val a11yManager = context.getSystemService(AccessibilityManager::class.java)
+        if (a11yManager != null) {
+            return a11yManager.getRecommendedTimeoutMillis(
+                originalTimeoutMs,
+                AccessibilityManager.FLAG_CONTENT_TEXT,
+            ).toLong()
+        }
+    }
+    return originalTimeoutMs.toLong()
+}

--- a/feature/appdetail/impl/src/main/kotlin/com/merxury/blocker/feature/appdetail/impl/AppDetailScreen.kt
+++ b/feature/appdetail/impl/src/main/kotlin/com/merxury/blocker/feature/appdetail/impl/AppDetailScreen.kt
@@ -113,6 +113,7 @@ import com.merxury.blocker.core.ui.AppDetailTabs.Receiver
 import com.merxury.blocker.core.ui.AppDetailTabs.Sdk
 import com.merxury.blocker.core.ui.AppDetailTabs.Service
 import com.merxury.blocker.core.ui.PreviewDevices
+import com.merxury.blocker.core.ui.ProcessingProgressSnackbar
 import com.merxury.blocker.core.ui.TabState
 import com.merxury.blocker.core.ui.TrackScreenViewEvent
 import com.merxury.blocker.core.ui.component.ComponentList
@@ -166,98 +167,97 @@ fun AppDetailScreen(
     val clipboardManager = LocalClipboard.current
     val context = LocalContext.current
     val cannotLaunchAppMessage = stringResource(string.feature_appdetail_api_cannot_launch_this_app)
-    AppDetailScreen(
-        appInfoUiState = appInfoUiState,
-        topAppBarUiState = topAppBarUiState,
-        componentListUiState = appInfoUiState.componentSearchUiState,
-        tabState = tabState,
-        showComponentDetailDialog = viewModel::showComponentDetailDialog,
-        navigateToRuleDetail = navigateToRuleDetail,
-        showComponentSortBottomSheet = viewModel::showComponentSortBottomSheet,
-        modifier = modifier.fillMaxSize(),
-        onLaunchAppClick = { packageName ->
-            val result = viewModel.launchApp(context, packageName)
-            if (!result) {
+    Box(modifier = modifier.fillMaxSize()) {
+        AppDetailScreen(
+            appInfoUiState = appInfoUiState,
+            topAppBarUiState = topAppBarUiState,
+            componentListUiState = appInfoUiState.componentSearchUiState,
+            tabState = tabState,
+            showComponentDetailDialog = viewModel::showComponentDetailDialog,
+            navigateToRuleDetail = navigateToRuleDetail,
+            showComponentSortBottomSheet = viewModel::showComponentSortBottomSheet,
+            modifier = Modifier.fillMaxSize(),
+            onLaunchAppClick = { packageName ->
+                val result = viewModel.launchApp(context, packageName)
+                if (!result) {
+                    scope.launch {
+                        snackbarHostState.showSnackbar(
+                            message = cannotLaunchAppMessage,
+                            duration = Short,
+                            withDismissAction = true,
+                        )
+                    }
+                }
+            },
+            switchTab = viewModel::switchTab,
+            onBackClick = onBackClick,
+            onSearchTextChange = viewModel::search,
+            onSearchModeChange = viewModel::changeSearchMode,
+            blockAllComponentsInPage = { viewModel.controlAllComponentsInPage(false) },
+            enableAllComponentsInPage = { viewModel.controlAllComponentsInPage(true) },
+            onExportRules = viewModel::exportBlockerRule,
+            onImportRules = viewModel::importBlockerRule,
+            onExportIfw = viewModel::exportIfwRule,
+            onImportIfw = viewModel::importIfwRule,
+            onResetIfw = viewModel::resetIfw,
+            onSwitchClick = viewModel::controlComponent,
+            onStopServiceClick = viewModel::stopService,
+            onLaunchActivityClick = viewModel::launchActivity,
+            onCopyNameClick = {
                 scope.launch {
-                    snackbarHostState.showSnackbar(
-                        message = cannotLaunchAppMessage,
-                        duration = Short,
-                        withDismissAction = true,
-                    )
+                    clipboardManager.setClipEntry(ClipEntry(ClipData.newPlainText(it, it)))
                 }
-            }
-        },
-        switchTab = viewModel::switchTab,
-        onBackClick = onBackClick,
-        onSearchTextChange = viewModel::search,
-        onSearchModeChange = viewModel::changeSearchMode,
-        blockAllComponentsInPage = {
-            viewModel.controlAllComponentsInPage(false) { current, total ->
-                showDisableProgress(context, snackbarHostState, scope, current, total)
-            }
-        },
-        enableAllComponentsInPage = {
-            viewModel.controlAllComponentsInPage(true) { current, total ->
-                showEnableProgress(context, snackbarHostState, scope, current, total)
-            }
-        },
-        onExportRules = viewModel::exportBlockerRule,
-        onImportRules = viewModel::importBlockerRule,
-        onExportIfw = viewModel::exportIfwRule,
-        onImportIfw = viewModel::importIfwRule,
-        onResetIfw = viewModel::resetIfw,
-        onSwitchClick = viewModel::controlComponent,
-        onStopServiceClick = viewModel::stopService,
-        onLaunchActivityClick = viewModel::launchActivity,
-        onCopyNameClick = {
-            scope.launch {
-                clipboardManager.setClipEntry(ClipEntry(ClipData.newPlainText(it, it)))
-            }
-        },
-        onCopyFullNameClick = {
-            scope.launch {
-                clipboardManager.setClipEntry(ClipEntry(ClipData.newPlainText(it, it)))
-            }
-        },
-        updateIconThemingState = updateIconThemingState,
-        onSelectAll = viewModel::selectAll,
-        blockAllSelectedComponents = { viewModel.controlAllSelectedComponents(false) },
-        enableAllSelectedComponents = { viewModel.controlAllSelectedComponents(true) },
-        switchSelectedMode = viewModel::switchSelectedMode,
-        onSelect = viewModel::selectItem,
-        onDeselect = viewModel::deselectItem,
-        blockAllInItem = {
-            viewModel.controlAllComponents(it, false) { current, total ->
-                showDisableProgress(context, snackbarHostState, scope, current, total)
-            }
-        },
-        enableAllInItem = {
-            viewModel.controlAllComponents(it, true) { current, total ->
-                showEnableProgress(context, snackbarHostState, scope, current, total)
-            }
-        },
-        shareAppRule = {
-            scope.launch {
-                viewModel.zipAppRule().collect { rule ->
-                    shareFile(context, rule, scope, snackbarHostState)
+            },
+            onCopyFullNameClick = {
+                scope.launch {
+                    clipboardManager.setClipEntry(ClipEntry(ClipData.newPlainText(it, it)))
                 }
-            }
-        },
-        shareAllRules = {
-            scope.launch {
-                viewModel.zipAllRule().collect { rule ->
-                    shareFile(context, rule, scope, snackbarHostState)
+            },
+            updateIconThemingState = updateIconThemingState,
+            onSelectAll = viewModel::selectAll,
+            blockAllSelectedComponents = { viewModel.controlAllSelectedComponents(false) },
+            enableAllSelectedComponents = { viewModel.controlAllSelectedComponents(true) },
+            switchSelectedMode = viewModel::switchSelectedMode,
+            onSelect = viewModel::selectItem,
+            onDeselect = viewModel::deselectItem,
+            blockAllInItem = { viewModel.controlAllComponents(it, false) },
+            enableAllInItem = { viewModel.controlAllComponents(it, true) },
+            shareAppRule = {
+                scope.launch {
+                    viewModel.zipAppRule().collect { rule ->
+                        shareFile(context, rule, scope, snackbarHostState)
+                    }
                 }
-            }
-        },
-        onShowAppInfoClick = { viewModel.showAppInfo(context) },
-        onEditIfwRuleClick = onEditIfwRuleClick,
-        onRefresh = {
-            viewModel.loadComponentList()
-            viewModel.updateComponentList()
-        },
-        showBackButton = showBackButton,
-    )
+            },
+            shareAllRules = {
+                scope.launch {
+                    viewModel.zipAllRule().collect { rule ->
+                        shareFile(context, rule, scope, snackbarHostState)
+                    }
+                }
+            },
+            onShowAppInfoClick = { viewModel.showAppInfo(context) },
+            onEditIfwRuleClick = onEditIfwRuleClick,
+            onRefresh = {
+                viewModel.loadComponentList()
+                viewModel.updateComponentList()
+            },
+            showBackButton = showBackButton,
+        )
+        val bottomInset = WindowInsets.systemBars.asPaddingValues()
+            .calculateBottomPadding()
+        ProcessingProgressSnackbar(
+            progress = appInfoUiState.processingProgress,
+            onDismiss = viewModel::dismissProcessingProgress,
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(
+                    start = 16.dp,
+                    end = 16.dp,
+                    bottom = 16.dp + bottomInset,
+                ),
+        )
+    }
     if (appInfoUiState.error != null) {
         BlockerErrorAlertDialog(
             title = appInfoUiState.error?.title.orEmpty(),
@@ -293,62 +293,6 @@ fun AppDetailScreen(
                     withDismissAction = true,
                 )
             }
-        }
-    }
-}
-
-private fun showEnableProgress(
-    context: Context,
-    snackbarHostState: SnackbarHostState,
-    scope: CoroutineScope,
-    current: Int,
-    total: Int,
-) {
-    scope.launch {
-        if (current == total) {
-            snackbarHostState.showSnackbar(
-                message = context.getString(uistring.core_ui_operation_completed),
-                duration = Short,
-                withDismissAction = true,
-            )
-        } else {
-            snackbarHostState.showSnackbar(
-                message = context.getString(
-                    uistring.core_ui_enabling_component_hint,
-                    current,
-                    total,
-                ),
-                duration = Short,
-                withDismissAction = false,
-            )
-        }
-    }
-}
-
-private fun showDisableProgress(
-    context: Context,
-    snackbarHostState: SnackbarHostState,
-    scope: CoroutineScope,
-    current: Int,
-    total: Int,
-) {
-    scope.launch {
-        if (current == total) {
-            snackbarHostState.showSnackbar(
-                message = context.getString(uistring.core_ui_operation_completed),
-                duration = Short,
-                withDismissAction = true,
-            )
-        } else {
-            snackbarHostState.showSnackbar(
-                message = context.getString(
-                    uistring.core_ui_disabling_component_hint,
-                    current,
-                    total,
-                ),
-                duration = Short,
-                withDismissAction = false,
-            )
         }
     }
 }

--- a/feature/appdetail/impl/src/main/kotlin/com/merxury/blocker/feature/appdetail/impl/AppDetailViewModel.kt
+++ b/feature/appdetail/impl/src/main/kotlin/com/merxury/blocker/feature/appdetail/impl/AppDetailViewModel.kt
@@ -79,6 +79,7 @@ import com.merxury.blocker.core.ui.AppDetailTabs.Provider
 import com.merxury.blocker.core.ui.AppDetailTabs.Receiver
 import com.merxury.blocker.core.ui.AppDetailTabs.Sdk
 import com.merxury.blocker.core.ui.AppDetailTabs.Service
+import com.merxury.blocker.core.ui.ProcessingProgress
 import com.merxury.blocker.core.ui.TabState
 import com.merxury.blocker.core.ui.data.UiMessage
 import com.merxury.blocker.core.ui.data.toErrorMessage
@@ -405,7 +406,7 @@ class AppDetailViewModel @AssistedInject constructor(
         }
     }
 
-    fun controlAllComponentsInPage(enable: Boolean, block: suspend (Int, Int) -> Unit) {
+    fun controlAllComponentsInPage(enable: Boolean) {
         controlComponentJob?.cancel()
         val currentComponentListUiState = _appInfoUiState.value.componentSearchUiState
         if (currentComponentListUiState !is Result.Success) {
@@ -427,7 +428,7 @@ class AppDetailViewModel @AssistedInject constructor(
 
                 else -> return@launch
             }
-            controlAllComponentsInternal(list, enable, block)
+            controlAllComponentsInternal(list, enable)
             analyticsHelper.logBatchOperationPerformed(enable)
         }
     }
@@ -435,11 +436,10 @@ class AppDetailViewModel @AssistedInject constructor(
     fun controlAllComponents(
         list: List<ComponentInfo>,
         enable: Boolean,
-        action: suspend (Int, Int) -> Unit,
     ) {
         controlComponentJob?.cancel()
         controlComponentJob = viewModelScope.launch(ioDispatcher + exceptionHandler) {
-            controlAllComponentsInternal(list, enable, action)
+            controlAllComponentsInternal(list, enable)
             analyticsHelper.logControlAllComponentsInSdkClicked(enable)
         }
     }
@@ -447,7 +447,7 @@ class AppDetailViewModel @AssistedInject constructor(
     private suspend fun controlAllComponentsInternal(
         list: List<ComponentInfo>,
         enable: Boolean,
-        action: suspend (Int, Int) -> Unit,
+        action: suspend (Int, Int) -> Unit = { _, _ -> },
     ) {
         val controllerType = userDataRepository.userData.first().controllerType
         var successCount = 0
@@ -456,6 +456,15 @@ class AppDetailViewModel @AssistedInject constructor(
             newState = enable,
         )
             .onStart {
+                _appInfoUiState.update {
+                    it.copy(
+                        processingProgress = ProcessingProgress(
+                            current = 0,
+                            total = list.size,
+                            isEnabling = enable,
+                        ),
+                    )
+                }
                 changeComponentsUiStatus(
                     changed = list,
                     controllerType = controllerType,
@@ -470,17 +479,33 @@ class AppDetailViewModel @AssistedInject constructor(
                     enabled = !enable,
                 )
                 _appInfoUiState.update {
-                    it.copy(error = exception.toErrorMessage())
+                    it.copy(
+                        error = exception.toErrorMessage(),
+                        processingProgress = null,
+                    )
                 }
             }
             .collect { _ ->
                 successCount++
+                _appInfoUiState.update {
+                    it.copy(
+                        processingProgress = ProcessingProgress(
+                            current = successCount,
+                            total = list.size,
+                            isEnabling = enable,
+                        ),
+                    )
+                }
                 action(successCount, list.size)
             }
     }
 
     fun dismissAlert() = _appInfoUiState.update {
         it.copy(error = null)
+    }
+
+    fun dismissProcessingProgress() = _appInfoUiState.update {
+        it.copy(processingProgress = null)
     }
 
     fun launchActivity(packageName: String, componentName: String) {
@@ -937,4 +962,5 @@ data class AppInfoUiState(
     val showComponentSortBottomSheet: Boolean = false,
     val showComponentDetailDialog: Boolean = false,
     val selectedComponentName: String = "",
+    val processingProgress: ProcessingProgress? = null,
 )

--- a/feature/ruledetail/impl/src/main/kotlin/com/merxury/blocker/feature/ruledetail/impl/RuleDetailScreen.kt
+++ b/feature/ruledetail/impl/src/main/kotlin/com/merxury/blocker/feature/ruledetail/impl/RuleDetailScreen.kt
@@ -17,7 +17,6 @@
 package com.merxury.blocker.feature.ruledetail.impl
 
 import android.content.ClipData
-import android.content.Context
 import androidx.compose.animation.core.FloatExponentialDecaySpec
 import androidx.compose.animation.core.animateDecay
 import androidx.compose.foundation.ExperimentalFoundationApi
@@ -39,7 +38,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SnackbarDuration.Short
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -59,7 +57,6 @@ import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.ClipEntry
 import androidx.compose.ui.platform.LocalClipboard
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -88,6 +85,7 @@ import com.merxury.blocker.core.model.data.GeneralRule
 import com.merxury.blocker.core.result.Result
 import com.merxury.blocker.core.result.Result.Loading
 import com.merxury.blocker.core.result.Result.Success
+import com.merxury.blocker.core.ui.ProcessingProgressSnackbar
 import com.merxury.blocker.core.ui.TabState
 import com.merxury.blocker.core.ui.TrackScreenViewEvent
 import com.merxury.blocker.core.ui.data.UiMessage
@@ -107,7 +105,6 @@ import com.merxury.blocker.feature.ruledetail.RuleDetailSortType
 import com.merxury.blocker.feature.ruledetail.impl.RuleInfoUiState.Error
 import com.merxury.blocker.feature.ruledetail.impl.component.RuleDescription
 import com.merxury.blocker.feature.ruledetail.impl.component.RuleMatchedAppList
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.launch
 import com.merxury.blocker.core.ui.R.string as uistring
@@ -119,6 +116,7 @@ fun RuleDetailScreen(
     snackbarHostState: SnackbarHostState,
     navigateToAppDetail: (String) -> Unit,
     updateIconThemingState: (IconThemingState) -> Unit,
+    modifier: Modifier = Modifier,
     showBackButton: Boolean = true,
     viewModel: RuleDetailViewModel = hiltViewModel(),
 ) {
@@ -127,46 +125,53 @@ fun RuleDetailScreen(
     val errorState by viewModel.errorState.collectAsStateWithLifecycle()
     val appBarUiState by viewModel.appBarUiState.collectAsStateWithLifecycle()
     val sortType by viewModel.sortType.collectAsStateWithLifecycle()
+    val processingProgress by viewModel.processingProgress.collectAsStateWithLifecycle()
     val clipboardManager = LocalClipboard.current
-    val context = LocalContext.current
     val scope = rememberCoroutineScope()
-    RuleDetailScreen(
-        ruleInfoUiState = ruleInfoUiState,
-        showBackButton = showBackButton,
-        onBackClick = onBackClick,
-        tabState = tabState,
-        switchTab = viewModel::switchTab,
-        appBarUiState = appBarUiState,
-        sortType = sortType,
-        onSortTypeChange = viewModel::updateSortType,
-        onStopServiceClick = viewModel::stopService,
-        onLaunchActivityClick = viewModel::launchActivity,
-        onCopyNameClick = {
-            scope.launch {
-                clipboardManager.setClipEntry(ClipEntry(ClipData.newPlainText(it, it)))
-            }
-        },
-        onCopyFullNameClick = {
-            scope.launch {
-                clipboardManager.setClipEntry(ClipEntry(ClipData.newPlainText(it, it)))
-            }
-        },
-        onBlockAllInItemClick = {
-            handleBlockAllInItemClick(context, viewModel, it, scope, snackbarHostState)
-        },
-        onEnableAllInItemClick = {
-            handleEnableAllInItemClick(viewModel, it, scope, snackbarHostState, context)
-        },
-        onBlockAllInPageClick = {
-            handleBlockAllInPageClick(viewModel, scope, snackbarHostState, context)
-        },
-        onEnableAllInPageClick = {
-            handleEnableAllInPageClick(viewModel, scope, snackbarHostState, context)
-        },
-        onSwitch = viewModel::controlComponent,
-        navigateToAppDetail = navigateToAppDetail,
-        updateIconThemingState = updateIconThemingState,
-    )
+    Box(modifier = modifier.fillMaxSize()) {
+        RuleDetailScreen(
+            ruleInfoUiState = ruleInfoUiState,
+            showBackButton = showBackButton,
+            onBackClick = onBackClick,
+            tabState = tabState,
+            switchTab = viewModel::switchTab,
+            appBarUiState = appBarUiState,
+            sortType = sortType,
+            onSortTypeChange = viewModel::updateSortType,
+            onStopServiceClick = viewModel::stopService,
+            onLaunchActivityClick = viewModel::launchActivity,
+            onCopyNameClick = {
+                scope.launch {
+                    clipboardManager.setClipEntry(ClipEntry(ClipData.newPlainText(it, it)))
+                }
+            },
+            onCopyFullNameClick = {
+                scope.launch {
+                    clipboardManager.setClipEntry(ClipEntry(ClipData.newPlainText(it, it)))
+                }
+            },
+            onBlockAllInItemClick = { viewModel.controlAllComponents(it, false) },
+            onEnableAllInItemClick = { viewModel.controlAllComponents(it, true) },
+            onBlockAllInPageClick = { viewModel.controlAllComponentsInPage(false) },
+            onEnableAllInPageClick = { viewModel.controlAllComponentsInPage(true) },
+            onSwitch = viewModel::controlComponent,
+            navigateToAppDetail = navigateToAppDetail,
+            updateIconThemingState = updateIconThemingState,
+        )
+        val bottomInset = WindowInsets.systemBars.asPaddingValues()
+            .calculateBottomPadding()
+        ProcessingProgressSnackbar(
+            progress = processingProgress,
+            onDismiss = viewModel::dismissProcessingProgress,
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(
+                    start = 16.dp,
+                    end = 16.dp,
+                    bottom = 16.dp + bottomInset,
+                ),
+        )
+    }
     if (errorState != null) {
         BlockerErrorAlertDialog(
             title = errorState?.title.orEmpty(),
@@ -177,114 +182,6 @@ fun RuleDetailScreen(
     DisposableEffect(Unit) {
         onDispose {
             updateIconThemingState(IconThemingState())
-        }
-    }
-}
-
-private fun handleEnableAllInPageClick(
-    viewModel: RuleDetailViewModel,
-    scope: CoroutineScope,
-    snackbarHostState: SnackbarHostState,
-    context: Context,
-) {
-    viewModel.controlAllComponentsInPage(true) { current, total ->
-        showEnableProgress(context, snackbarHostState, scope, current, total)
-    }
-}
-
-private fun handleBlockAllInPageClick(
-    viewModel: RuleDetailViewModel,
-    scope: CoroutineScope,
-    snackbarHostState: SnackbarHostState,
-    context: Context,
-) {
-    viewModel.controlAllComponentsInPage(false) { current, total ->
-        showDisableProgress(
-            context,
-            snackbarHostState,
-            scope,
-            current,
-            total,
-        )
-    }
-}
-
-private fun handleEnableAllInItemClick(
-    viewModel: RuleDetailViewModel,
-    it: List<ComponentInfo>,
-    scope: CoroutineScope,
-    snackbarHostState: SnackbarHostState,
-    context: Context,
-) {
-    viewModel.controlAllComponents(it, true) { current, total ->
-        showEnableProgress(context, snackbarHostState, scope, current, total)
-    }
-}
-
-private fun handleBlockAllInItemClick(
-    context: Context,
-    viewModel: RuleDetailViewModel,
-    it: List<ComponentInfo>,
-    scope: CoroutineScope,
-    snackbarHostState: SnackbarHostState,
-) {
-    viewModel.controlAllComponents(it, false) { current, total ->
-        showDisableProgress(context, snackbarHostState, scope, current, total)
-    }
-}
-
-private fun showEnableProgress(
-    context: Context,
-    snackbarHostState: SnackbarHostState,
-    scope: CoroutineScope,
-    current: Int,
-    total: Int,
-) {
-    scope.launch {
-        if (current == total) {
-            snackbarHostState.showSnackbar(
-                message = context.getString(uistring.core_ui_operation_completed),
-                duration = Short,
-                withDismissAction = true,
-            )
-        } else {
-            snackbarHostState.showSnackbar(
-                message = context.getString(
-                    uistring.core_ui_enabling_component_hint,
-                    current,
-                    total,
-                ),
-                duration = Short,
-                withDismissAction = false,
-            )
-        }
-    }
-}
-
-private fun showDisableProgress(
-    context: Context,
-    snackbarHostState: SnackbarHostState,
-    scope: CoroutineScope,
-    current: Int,
-    total: Int,
-) {
-    scope.launch {
-        if (current == total) {
-            snackbarHostState.showSnackbar(
-                message = context.getString(uistring.core_ui_operation_completed),
-                duration = Short,
-                withDismissAction = true,
-            )
-        } else {
-            snackbarHostState.showSnackbar(
-                message = context.getString(
-                    uistring.core_ui_disabling_component_hint,
-                    current,
-                    total,
-                ),
-                duration = Short,
-                withDismissAction = false,
-            )
         }
     }
 }

--- a/feature/ruledetail/impl/src/main/kotlin/com/merxury/blocker/feature/ruledetail/impl/RuleDetailViewModel.kt
+++ b/feature/ruledetail/impl/src/main/kotlin/com/merxury/blocker/feature/ruledetail/impl/RuleDetailViewModel.kt
@@ -49,6 +49,7 @@ import com.merxury.blocker.core.model.data.ControllerType
 import com.merxury.blocker.core.model.data.GeneralRule
 import com.merxury.blocker.core.model.data.InstalledApp
 import com.merxury.blocker.core.result.Result
+import com.merxury.blocker.core.ui.ProcessingProgress
 import com.merxury.blocker.core.ui.TabState
 import com.merxury.blocker.core.ui.data.UiMessage
 import com.merxury.blocker.core.ui.data.toErrorMessage
@@ -123,6 +124,8 @@ class RuleDetailViewModel @AssistedInject constructor(
     val tabState: StateFlow<TabState<RuleDetailTabs>> = _tabState.asStateFlow()
     private val _appBarUiState = MutableStateFlow(AppBarUiState(actions = getAppBarAction()))
     val appBarUiState: StateFlow<AppBarUiState> = _appBarUiState.asStateFlow()
+    private val _processingProgress = MutableStateFlow<ProcessingProgress?>(null)
+    val processingProgress: StateFlow<ProcessingProgress?> = _processingProgress.asStateFlow()
     private var currentSearchKeyword: List<String> = emptyList()
     private var loadRuleDetailJob: Job? = null
     private var controlComponentJob: Job? = null
@@ -171,7 +174,7 @@ class RuleDetailViewModel @AssistedInject constructor(
         }
     }
 
-    fun controlAllComponentsInPage(enable: Boolean, action: (Int, Int) -> Unit) {
+    fun controlAllComponentsInPage(enable: Boolean) {
         controlComponentJob?.cancel()
         controlComponentJob = viewModelScope.launch {
             analyticsHelper.logControlAllInPageClicked(newState = enable)
@@ -188,26 +191,24 @@ class RuleDetailViewModel @AssistedInject constructor(
             }
             val list = matchedAppState.data
                 .flatMap { it.componentList }
-            controlAllComponentsInternal(list, enable, action)
+            controlAllComponentsInternal(list, enable)
         }
     }
 
     fun controlAllComponents(
         list: List<ComponentInfo>,
         enable: Boolean,
-        action: (Int, Int) -> Unit,
     ) {
         controlComponentJob?.cancel()
         controlComponentJob = viewModelScope.launch {
             analyticsHelper.logControlAllComponentsClicked(newState = enable)
-            controlAllComponentsInternal(list, enable, action)
+            controlAllComponentsInternal(list, enable)
         }
     }
 
     private suspend fun controlAllComponentsInternal(
         list: List<ComponentInfo>,
         enable: Boolean,
-        action: suspend (Int, Int) -> Unit,
     ) {
         val controllerType = userDataRepository.userData.first().controllerType
         var successCount = 0
@@ -216,15 +217,25 @@ class RuleDetailViewModel @AssistedInject constructor(
             newState = enable,
         )
             .onStart {
+                _processingProgress.value = ProcessingProgress(
+                    current = 0,
+                    total = list.size,
+                    isEnabling = enable,
+                )
                 changeComponentUiStatus(list, controllerType, enable)
             }
             .catch { exception ->
                 changeComponentUiStatus(list, controllerType, !enable)
+                _processingProgress.value = null
                 _errorState.emit(exception.toErrorMessage())
             }
             .collect { _ ->
                 successCount++
-                action(successCount, list.size)
+                _processingProgress.value = ProcessingProgress(
+                    current = successCount,
+                    total = list.size,
+                    isEnabling = enable,
+                )
             }
     }
 
@@ -318,6 +329,10 @@ class RuleDetailViewModel @AssistedInject constructor(
 
     fun dismissAlert() = viewModelScope.launch {
         _errorState.emit(null)
+    }
+
+    fun dismissProcessingProgress() {
+        _processingProgress.value = null
     }
 
     fun launchActivity(packageName: String, componentName: String) {


### PR DESCRIPTION
## Summary

Fixes #1504

- Replaced `SnackbarHostState.showSnackbar()` progress display with a state-driven `ProcessingProgressSnackbar` composable that updates instantly
- Applied fix to both **AppDetail** and **RuleDetail** screens (same bug existed in both)
- Extracted shared `ProcessingProgress` data class and `ProcessingProgressSnackbar` composable to `core:ui`

## Root Cause

`showSnackbar()` is a suspend function that enforces a minimum ~3-second display (`SnackbarDuration.Short`). During batch operations processing 100+ components, each emission queued a new snackbar — the UI showed "5/100" long after all 100 components were already done.

## Solution

Progress is now a piece of `StateFlow` state in the ViewModel. The composable reads it reactively and re-renders instantly on every update, bypassing the snackbar queue entirely. Progress auto-clears 2 seconds after completion.

## Test plan

- [x] `./gradlew :feature:appdetail:impl:testFossDebugUnitTest` passes
- [x] `./gradlew :feature:ruledetail:impl:testFossDebugUnitTest` passes
- [x] `./gradlew spotlessCheck` passes
- [ ] Manual: batch disable all components in an app → progress updates in real-time, shows "Operation completed" briefly, then dismisses