### PR TITLE
Support Shizuku system UID for PM component control

### DIFF
--- a/core/data/src/main/kotlin/com/merxury/blocker/core/data/util/AppPermissionMonitor.kt
+++ b/core/data/src/main/kotlin/com/merxury/blocker/core/data/util/AppPermissionMonitor.kt
@@ -27,6 +27,7 @@ import com.merxury.blocker.core.data.respository.userdata.UserDataRepository
 import com.merxury.blocker.core.data.util.PermissionStatus.NO_PERMISSION
 import com.merxury.blocker.core.data.util.PermissionStatus.ROOT_USER
 import com.merxury.blocker.core.data.util.PermissionStatus.SHELL_USER
+import com.merxury.blocker.core.data.util.PermissionStatus.SYSTEM_USER
 import com.merxury.blocker.core.di.ApplicationScope
 import com.merxury.blocker.core.model.data.ControllerType
 import com.merxury.blocker.core.model.data.ControllerType.PM
@@ -43,6 +44,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 private const val SHELL_UID = 2000
+private const val SYSTEM_UID = 1000
 private const val ROOT_UID = 0
 
 @Singleton
@@ -75,9 +77,18 @@ class AppPermissionMonitor @Inject constructor(
     private suspend fun initController(type: ControllerType) {
         Timber.d("Initialize controller: $type")
         if (type == SHIZUKU) {
-            if (controllerStatus[SHIZUKU] == ROOT_USER || controllerStatus[SHIZUKU] == SHELL_USER) {
-                Timber.i("No need to re-initialize shizuku controller")
-                return
+            when (controllerStatus[SHIZUKU]) {
+                ROOT_USER,
+                SYSTEM_USER,
+                SHELL_USER,
+                -> {
+                    Timber.i("No need to re-initialize shizuku controller")
+                    return
+                }
+
+                NO_PERMISSION,
+                null,
+                -> Unit
             }
             if (!shizukuInitializer.hasPermission()) {
                 val result = shizukuInitializer.registerShizuku()
@@ -114,6 +125,7 @@ class AppPermissionMonitor @Inject constructor(
     private fun updatePermissionStatusFromUid(uid: Int) {
         when (uid) {
             ROOT_UID -> controllerStatus[SHIZUKU] = ROOT_USER
+            SYSTEM_UID -> controllerStatus[SHIZUKU] = SYSTEM_USER
             SHELL_UID -> controllerStatus[SHIZUKU] = SHELL_USER
             else -> controllerStatus[SHIZUKU] = NO_PERMISSION
         }

--- a/core/data/src/main/kotlin/com/merxury/blocker/core/data/util/PermissionStatus.kt
+++ b/core/data/src/main/kotlin/com/merxury/blocker/core/data/util/PermissionStatus.kt
@@ -18,6 +18,7 @@ package com.merxury.blocker.core.data.util
 
 enum class PermissionStatus {
     ROOT_USER,
+    SYSTEM_USER,
     SHELL_USER,
     NO_PERMISSION,
 }

--- a/core/data/src/test/kotlin/com/merxury/blocker/core/data/util/AppPermissionMonitorTest.kt
+++ b/core/data/src/test/kotlin/com/merxury/blocker/core/data/util/AppPermissionMonitorTest.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 Blocker
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.merxury.blocker.core.data.util
+
+import app.cash.turbine.test
+import com.merxury.blocker.core.model.data.ControllerType.SHIZUKU
+import com.merxury.blocker.core.testing.controller.FakeAppController
+import com.merxury.blocker.core.testing.controller.FakeController
+import com.merxury.blocker.core.testing.controller.FakeServiceController
+import com.merxury.blocker.core.testing.controller.FakeShizukuInitializer
+import com.merxury.blocker.core.testing.repository.TestUserDataRepository
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class AppPermissionMonitorTest {
+    @Test
+    fun givenShizukuSystemUid_whenObservePermission_thenSystemUser() = runTest {
+        val userDataRepository = TestUserDataRepository()
+        val monitor = AppPermissionMonitor(
+            userDataRepository = userDataRepository,
+            shizukuInitializer = FakeShizukuInitializer(shizukuUid = SYSTEM_UID),
+            rootApiController = FakeController(rootGranted = true),
+            rootApiAppController = FakeAppController(rootGranted = true),
+            rootApiServiceController = FakeServiceController(),
+            appScope = backgroundScope,
+        )
+
+        userDataRepository.setControllerType(SHIZUKU)
+
+        monitor.permissionStatus.test {
+            assertEquals(PermissionStatus.SYSTEM_USER, awaitItem())
+        }
+    }
+
+    private companion object {
+        const val SYSTEM_UID = 1000
+    }
+}

--- a/core/testing/src/main/kotlin/com/merxury/blocker/core/testing/controller/FakeShizukuInitializer.kt
+++ b/core/testing/src/main/kotlin/com/merxury/blocker/core/testing/controller/FakeShizukuInitializer.kt
@@ -19,15 +19,24 @@ package com.merxury.blocker.core.testing.controller
 import com.merxury.blocker.core.controllers.shizuku.IShizukuInitializer
 import com.merxury.blocker.core.controllers.shizuku.RegisterShizukuResult
 
-class FakeShizukuInitializer : IShizukuInitializer {
+class FakeShizukuInitializer(
+    var shizukuUid: Int = 0,
+    var permissionGranted: Boolean = true,
+) : IShizukuInitializer {
 
-    override suspend fun registerShizuku(): RegisterShizukuResult = RegisterShizukuResult(true, 0)
+    var registerCallCount = 0
+        private set
+
+    override suspend fun registerShizuku(): RegisterShizukuResult {
+        registerCallCount++
+        return RegisterShizukuResult(permissionGranted, if (permissionGranted) shizukuUid else -1)
+    }
 
     override fun unregisterShizuku() {
         // Do nothing
     }
 
-    override fun hasPermission(): Boolean = true
+    override fun hasPermission(): Boolean = permissionGranted
 
-    override fun getUid(): Int = 0
+    override fun getUid(): Int = shizukuUid
 }


### PR DESCRIPTION
## Scope

This PR implements the narrowed PM component enable/disable behavior for Shizuku system UID. It intentionally does not close the broader IFW system-mode request in #1547.

## Test Plan

- [x] `./gradlew :core:data:testFossDebugUnitTest :app-compose:compileFossDebugKotlin :core:data:spotlessCheck :core:testing:spotlessCheck`
- [x] `git diff --check origin/main...HEAD`

Is this your first Pull Request?

No.

- [ ] Run `./tools/setup.sh` (not applicable)
- [ ] Import the code formatting style as explained in [the setup script](/tools/setup.sh#L40). (not applicable)

Refs #1547
